### PR TITLE
Changes to allow compilation on master branch

### DIFF
--- a/Distributions/Library/Makefile_Library_Dependencies
+++ b/Distributions/Library/Makefile_Library_Dependencies
@@ -1,6 +1,9 @@
 wlKindModule.o: \
   wlKindModule.f90
 
+wlParallelModule.o: \
+  wlParallelModule.f90
+
 wlGridModule.o: \
   wlKindModule.o \
   wlGridModule.f90

--- a/Distributions/Library/Makefile_Library_ObjectFiles
+++ b/Distributions/Library/Makefile_Library_ObjectFiles
@@ -1,5 +1,6 @@
 WL_LIBRARY = \
   wlKindModule.o \
+  wlParallelModule.o \
   wlGridModule.o \
   wlThermoStateModule.o \
   wlDependentVariablesModule.o \

--- a/Distributions/Library/Makefile_Objects
+++ b/Distributions/Library/Makefile_Objects
@@ -2,6 +2,7 @@
 
 WL_LIBRARYMODULES = \
 wlKindModule.o \
+wlParallelModule.o \
 wlThermoStateModule.o \
 wlDependentVariablesModule.o \
 wlGridModule.o \

--- a/Distributions/Library/wlIOModuleHDF.F90
+++ b/Distributions/Library/wlIOModuleHDF.F90
@@ -709,14 +709,14 @@ CONTAINS
   SUBROUTINE WriteVersionAttribute(group_id)
 
     INTEGER(HID_T), INTENT(IN) :: group_id
-    CHARACTER(LEN=100), DIMENSION(4) :: tmpstring
+    !!$CHARACTER(LEN=100), DIMENSION(4) :: tmpstring
 
-    tmpstring(1) = "Git hash:                "//GIT_HASH
-    tmpstring(2) = "Git branch:              "//GIT_BRANCH
-    tmpstring(3) = "Git date of last commit: "//GIT_DATE
-    tmpstring(4) = "Git URL:                 "//GIT_URL
+    !!$tmpstring(1) = "Git hash:                "//GIT_HASH
+    !!$tmpstring(2) = "Git branch:              "//GIT_BRANCH
+    !!$tmpstring(3) = "Git date of last commit: "//GIT_DATE
+    !!$tmpstring(4) = "Git URL:                 "//GIT_URL
 
-    CALL WriteGroupAttributeHDF_string("Version", tmpstring, group_id)
+    !!$CALL WriteGroupAttributeHDF_string("Version", tmpstring, group_id)
 
   END SUBROUTINE WriteVersionAttribute
   

--- a/Distributions/OpacitySource/Makefile_OpacitySource_ObjectFiles
+++ b/Distributions/OpacitySource/Makefile_OpacitySource_ObjectFiles
@@ -1,5 +1,4 @@
 WL_OPACITYSOURCE = \
   wlOpacityFieldsModule.o \
   wlOpacityTableModule.o \
-  wlParallelModule.o \
   wlOpacityTableIOModuleHDF.o


### PR DESCRIPTION
1. Commented out writing of git info because the variables were not defined.
2. Added wlParallelModule.f90 to build system so it can be detected by, e.g., thornado's build system
3. Remove extra wlParallelModule.o from ObjectFiles file in OpacitySource directory